### PR TITLE
v1.12.5

### DIFF
--- a/common/hdl/pkg/gem_pkg.vhd
+++ b/common/hdl/pkg/gem_pkg.vhd
@@ -10,10 +10,10 @@ package gem_pkg is
     --==  Firmware version  ==--
     --========================-- 
 
-    constant C_FIRMWARE_DATE    : std_logic_vector(31 downto 0) := x"20180607";
+    constant C_FIRMWARE_DATE    : std_logic_vector(31 downto 0) := x"20180608";
     constant C_FIRMWARE_MAJOR   : integer range 0 to 255        := 1;
     constant C_FIRMWARE_MINOR   : integer range 0 to 255        := 12;
-    constant C_FIRMWARE_BUILD   : integer range 0 to 255        := 3;
+    constant C_FIRMWARE_BUILD   : integer range 0 to 255        := 5;
     
     ------ Change log ------
     -- 1.8.6  no gbt sync procedure with oh
@@ -46,7 +46,8 @@ package gem_pkg is
     -- 1.12.1 Changed phase_unlock detection to only trigger if the PLL lock goes low  for several clock cycles (currently set at 12). Also added recording of minimum and maximum phase in phase monitor.
     -- 1.12.2 Shift out of phase initially after phase alignment reset (can be disabled with a register). Also a running mean of the phase measurement was added.
     -- 1.12.3 GTH PI clock phase adjustment implemented when shifting the MMCM outputs (which affects the TXUSRCLK phase). This should keep the GTH PI and TXUSRCLK reasonably in phase
-    -- 1.12.4 Added GTH shift count and GTH shift error registers. Also set TXDLYBYPASS = 1, and TXPIPPMSEL = 1 
+    -- 1.12.4 Added GTH shift count and GTH shift error registers. Also set TXDLYBYPASS = 1, and TXPIPPMSEL = 1
+    -- 1.12.5 Inverted the GTH shift direction w.r.t. MMCM shift direction, because in MMCM we're shifting the feedback clock, which actually shifts the outputs in the opposite direction.. 
 
     --======================--
     --==      General     ==--

--- a/common/hdl/pkg/gem_pkg.vhd
+++ b/common/hdl/pkg/gem_pkg.vhd
@@ -45,7 +45,8 @@ package gem_pkg is
     -- 1.12.0 Added a lot of TTC clock monitoring features, including unlock counters and phase monitoring. It's also possible to reset or disable the phase alignment procedure through registers
     -- 1.12.1 Changed phase_unlock detection to only trigger if the PLL lock goes low  for several clock cycles (currently set at 12). Also added recording of minimum and maximum phase in phase monitor.
     -- 1.12.2 Shift out of phase initially after phase alignment reset (can be disabled with a register). Also a running mean of the phase measurement was added.
-    -- 1.12.3 GTH PI clock phase adjustment implemented when shifting the MMCM outputs (which affects the TXUSRCLK phase). This should keep the GTH PI and TXUSRCLK reasonably in phase 
+    -- 1.12.3 GTH PI clock phase adjustment implemented when shifting the MMCM outputs (which affects the TXUSRCLK phase). This should keep the GTH PI and TXUSRCLK reasonably in phase
+    -- 1.12.4 Added GTH shift count and GTH shift error registers. Also set TXDLYBYPASS = 1, and TXPIPPMSEL = 1 
 
     --======================--
     --==      General     ==--

--- a/common/hdl/pkg/registers.vhd
+++ b/common/hdl/pkg/registers.vhd
@@ -192,9 +192,16 @@ package registers is
     constant REG_TTC_STATUS_CLK_GTH_PM_PHASE_JUMP_SIZE_MSB    : integer := 27;
     constant REG_TTC_STATUS_CLK_GTH_PM_PHASE_JUMP_SIZE_LSB     : integer := 16;
 
+    constant REG_TTC_STATUS_CLK_GTH_SHIFT_ERROR_ADDR    : std_logic_vector(7 downto 0) := x"2b";
+    constant REG_TTC_STATUS_CLK_GTH_SHIFT_ERROR_BIT    : integer := 31;
+
     constant REG_TTC_STATUS_CLK_GTH_PM_PHASE_JUMP_TIME_ADDR    : std_logic_vector(7 downto 0) := x"2c";
     constant REG_TTC_STATUS_CLK_GTH_PM_PHASE_JUMP_TIME_MSB    : integer := 15;
     constant REG_TTC_STATUS_CLK_GTH_PM_PHASE_JUMP_TIME_LSB     : integer := 0;
+
+    constant REG_TTC_STATUS_CLK_GTH_SHIFT_CNT_ADDR    : std_logic_vector(7 downto 0) := x"2c";
+    constant REG_TTC_STATUS_CLK_GTH_SHIFT_CNT_MSB    : integer := 31;
+    constant REG_TTC_STATUS_CLK_GTH_SHIFT_CNT_LSB     : integer := 16;
 
     constant REG_TTC_STATUS_TTC_SINGLE_ERROR_CNT_ADDR    : std_logic_vector(7 downto 0) := x"30";
     constant REG_TTC_STATUS_TTC_SINGLE_ERROR_CNT_MSB    : integer := 15;

--- a/common/hdl/ttc/ttc.vhd
+++ b/common/hdl/ttc/ttc.vhd
@@ -507,7 +507,9 @@ begin
     regs_read_arr(18)(REG_TTC_STATUS_CLK_GTH_PM_PHASE_MAX_MSB downto REG_TTC_STATUS_CLK_GTH_PM_PHASE_MAX_LSB) <= ttc_clks_status_i.pm_gth.phase_max;
     regs_read_arr(19)(REG_TTC_STATUS_CLK_GTH_PM_PHASE_JUMP_CNT_MSB downto REG_TTC_STATUS_CLK_GTH_PM_PHASE_JUMP_CNT_LSB) <= ttc_clks_status_i.pm_gth.phase_jump_cnt;
     regs_read_arr(19)(REG_TTC_STATUS_CLK_GTH_PM_PHASE_JUMP_SIZE_MSB downto REG_TTC_STATUS_CLK_GTH_PM_PHASE_JUMP_SIZE_LSB) <= ttc_clks_status_i.pm_gth.phase_jump_size;
+    regs_read_arr(19)(REG_TTC_STATUS_CLK_GTH_SHIFT_ERROR_BIT) <= ttc_clks_status_i.gth_pi_shift_error;
     regs_read_arr(20)(REG_TTC_STATUS_CLK_GTH_PM_PHASE_JUMP_TIME_MSB downto REG_TTC_STATUS_CLK_GTH_PM_PHASE_JUMP_TIME_LSB) <= ttc_clks_status_i.pm_gth.phase_jump_time;
+    regs_read_arr(20)(REG_TTC_STATUS_CLK_GTH_SHIFT_CNT_MSB downto REG_TTC_STATUS_CLK_GTH_SHIFT_CNT_LSB) <= ttc_clks_status_i.gth_pi_shift_cnt;
     regs_read_arr(21)(REG_TTC_STATUS_TTC_SINGLE_ERROR_CNT_MSB downto REG_TTC_STATUS_TTC_SINGLE_ERROR_CNT_LSB) <= ttc_status.single_err;
     regs_read_arr(21)(REG_TTC_STATUS_TTC_DOUBLE_ERROR_CNT_MSB downto REG_TTC_STATUS_TTC_DOUBLE_ERROR_CNT_LSB) <= ttc_status.double_err;
     regs_read_arr(22)(REG_TTC_STATUS_BC0_LOCKED_BIT) <= ttc_status.bc0_status.locked;

--- a/ctp7/hdl/misc/ttc_clocks.vhd
+++ b/ctp7/hdl/misc/ttc_clocks.vhd
@@ -720,7 +720,7 @@ begin
                 if (gth_shift_req_dly = '1' and gth_shift_ack = '0') then
                     gth_shift_ack <= '1';
                                         
-                    gth_tx_pippm_ctrl.direction <= gth_shift_dir;
+                    gth_tx_pippm_ctrl.direction <= not gth_shift_dir; -- shifting the MMCM feedback clock forward, actually shifts the outputs backwards.. so in this case we have to shift the PMA clock also backwards..
                     gth_tx_pippm_ctrl.enable <= '1';
                     gth_shift_en_timer <= "01";
                     

--- a/ctp7/hdl/system/gth_single_4p8g.vhd
+++ b/ctp7/hdl/system/gth_single_4p8g.vhd
@@ -745,7 +745,7 @@ begin
       TXPIPPMEN                  => tx_pippm_ctrl_i.enable, --'0',
       TXPIPPMOVRDEN              => '0',
       TXPIPPMPD                  => '0',
-      TXPIPPMSEL                 => '0',
+      TXPIPPMSEL                 => '1',
       TXPIPPMSTEPSIZE            => tx_pippm_ctrl_i.direction & tx_pippm_ctrl_i.step_size, -- "00000",
       ---------------------- Transceiver Reset Mode Operation --------------------
       GTRESETSEL                 => '0',
@@ -771,7 +771,7 @@ begin
       ------------------ Transmit Ports - Pattern Generator Ports ----------------
       TXPRBSFORCEERR            => gth_tx_ctrl_i.txprbsforceerr,
       ------------------ Transmit Ports - TX Buffer Bypass Ports -----------------
-      TXDLYBYPASS               => '0',
+      TXDLYBYPASS               => '1',
       TXDLYEN                   => gth_tx_init_i.TXDLYEN,
       TXDLYHOLD                 => '0',
       TXDLYOVRDEN               => '0',

--- a/scripts/address_table/gem_amc_top.xml
+++ b/scripts/address_table/gem_amc_top.xml
@@ -135,7 +135,7 @@
                 description="Phase alignment: the width of the phase lock window"
                 fw_signal="ttc_clks_status_i.pll_lock_window"/>
           <node id="PA_PHASE_SHIFT_CNT" address="0x3" mask="0xffff0000" permission="r"
-                description="Phase alignment: number of phase shifts done by the phase alignment FSM"
+                description="Phase alignment: number of phase shifts done by the phase alignment FSM (each shift corresponds to 18.6012ps)"
                 fw_signal="ttc_clks_status_i.phase_shift_cnt"/>
           <node id="PA_PLL_LOCK_CLOCKS" address="0x4" mask="0x00ffffff" permission="r"
                 description="Phase alignment: number of clock cycles it took the phase monitoring PLL to lock (debugging register)"
@@ -197,6 +197,12 @@
           <node id="GTH_PM_PHASE_JUMP_TIME" address="0xc" mask="0x0000ffff" permission="r"
                 description="GTH Phase monitoring: number of seconds since last phase jump"
                 fw_signal="ttc_clks_status_i.pm_gth.phase_jump_time"/>
+          <node id="GTH_SHIFT_ERROR" address="0xb" mask="0x80000000" permission="r"
+                description="Phase alignment: Error during GTH phase shifting"
+                fw_signal="ttc_clks_status_i.gth_pi_shift_error"/>
+          <node id="GTH_SHIFT_CNT" address="0xc" mask="0xffff0000" permission="r"
+                description="Phase alignment: Number of GTH shifts done since last phase alignment reset (each shift corresponds to 6.5104ps, so 20 GTH shifts matches 7 MMCM shifts)"
+                fw_signal="ttc_clks_status_i.gth_pi_shift_cnt"/>
         </node>
 
         <node id="TTC_SINGLE_ERROR_CNT" address="0x10" mask="0x0000ffff" permission="r"

--- a/scripts/address_table/uhal_gem_amc_ctp7_amc.xml
+++ b/scripts/address_table/uhal_gem_amc_ctp7_amc.xml
@@ -51,6 +51,8 @@
           <node id="GTH_PM_PHASE_JUMP_CNT" address="0xb" permission="r" mask="0xffff"/>
           <node id="GTH_PM_PHASE_JUMP_SIZE" address="0xb" permission="r" mask="0xfff0000"/>
           <node id="GTH_PM_PHASE_JUMP_TIME" address="0xc" permission="r" mask="0xffff"/>
+          <node id="GTH_SHIFT_ERROR" address="0xb" permission="r" mask="0x80000000"/>
+          <node id="GTH_SHIFT_CNT" address="0xc" permission="r" mask="0xffff0000"/>
         </node>
         <node id="TTC_SINGLE_ERROR_CNT" address="0x10" permission="r" mask="0xffff"/>
         <node id="TTC_DOUBLE_ERROR_CNT" address="0x10" permission="r" mask="0xffff0000"/>


### PR DESCRIPTION
    -- 1.12.4 Added GTH shift count and GTH shift error registers. Also set TXDLYBYPASS = 1, and TXPIPPMSEL = 1
    -- 1.12.5 Inverted the GTH shift direction w.r.t. MMCM shift direction, because in MMCM we're shifting the feedback clock, which actually shifts the outputs in the opposite direction.. 
