### PR TITLE
v3.8.3 -- bugfix in OH FPGA communication, added resync and BC0 markers to trigger receiver

### DIFF
--- a/common/hdl/gem_amc.vhd
+++ b/common/hdl/gem_amc.vhd
@@ -351,7 +351,7 @@ begin
         i_optohybrid_single : entity work.optohybrid
             generic map(
                 g_OH_IDX        => std_logic_vector(to_unsigned(i, 4)),
-                g_DEBUG         => i = 4
+                g_DEBUG         => i = 1
             )
             port map(
                 reset_i                 => reset or link_reset,

--- a/common/hdl/gem_amc.vhd
+++ b/common/hdl/gem_amc.vhd
@@ -597,7 +597,8 @@ begin
             link_status_arr_o           => gbt_link_status_arr
         );
 
-    i_gbt_link_mux : entity work.gbt_link_mux(gbt_link_mux_ge21)
+--    i_gbt_link_mux : entity work.gbt_link_mux(gbt_link_mux_ge21)
+    i_gbt_link_mux : entity work.gbt_link_mux(gbt_link_mux_ge11)
         generic map(
             g_NUM_OF_OHs  => g_NUM_OF_OHs
         )

--- a/common/hdl/oh/link/link_rx_trigger.vhd
+++ b/common/hdl/oh/link/link_rx_trigger.vhd
@@ -77,6 +77,8 @@ architecture Behavioral of link_rx_trigger is
 
     constant FRAME_MARKERS          : t_std8_array(0 to 3) := (x"bc", x"f7", x"fb", x"fd");
     constant OVERFLOW_FRAME_MARKER  : std_logic_vector(7 downto 0) := x"fc";
+    constant BC0_FRAME_MARKER       : std_logic_vector(7 downto 0) := x"1c";
+    constant RESYNC_FRAME_MARKER    : std_logic_vector(7 downto 0) := x"3c";
 
     type state_t is (COMMA, DATA_0, DATA_1, DATA_2);    
     
@@ -106,7 +108,7 @@ begin
             else
                 case state is
                     when COMMA =>
-                        if (rx_kchar_i(1 downto 0) = "01" and ((rx_data_i(7 downto 0) = FRAME_MARKERS(frame_counter)) or (rx_data_i(7 downto 0) = OVERFLOW_FRAME_MARKER))) then
+                        if (rx_kchar_i(1 downto 0) = "01" and ((rx_data_i(7 downto 0) = FRAME_MARKERS(frame_counter)) or (rx_data_i(7 downto 0) = OVERFLOW_FRAME_MARKER) or (rx_data_i(7 downto 0) = BC0_FRAME_MARKER) or (rx_data_i(7 downto 0) = RESYNC_FRAME_MARKER))) then
                             state <= DATA_0;
                             if (frame_counter = 3) then
                                 frame_counter <= 0;
@@ -138,7 +140,7 @@ begin
                 case state is
                     when COMMA =>
                         fifo_we <= '0';
-                        if (rx_kchar_i(1 downto 0) = "01" and ((rx_data_i(7 downto 0) = FRAME_MARKERS(frame_counter)) or (rx_data_i(7 downto 0) = OVERFLOW_FRAME_MARKER))) then
+                        if (rx_kchar_i(1 downto 0) = "01" and ((rx_data_i(7 downto 0) = FRAME_MARKERS(frame_counter)) or (rx_data_i(7 downto 0) = OVERFLOW_FRAME_MARKER) or (rx_data_i(7 downto 0) = BC0_FRAME_MARKER) or (rx_data_i(7 downto 0) = RESYNC_FRAME_MARKER))) then
                             reset_done <= '1';
                             if (fifo_we = '1') then
                                 missed_comma_err <= '0'; -- deassert it only if it's the first clock we're in the COMMA state

--- a/common/hdl/oh/link/link_rx_trigger.vhd
+++ b/common/hdl/oh/link/link_rx_trigger.vhd
@@ -138,7 +138,7 @@ begin
                 sbit_overflow <= '0';
             else
                 
-                if (reset_cntdown /= x"ff") then
+                if (reset_cntdown /= x"00") then
                     reset_cntdown <= reset_cntdown - 1;
                 end if;
                 

--- a/common/hdl/pkg/gem_pkg.vhd
+++ b/common/hdl/pkg/gem_pkg.vhd
@@ -10,10 +10,10 @@ package gem_pkg is
     --==  Firmware version  ==--
     --========================-- 
 
-    constant C_FIRMWARE_DATE    : std_logic_vector(31 downto 0) := x"20190127";
+    constant C_FIRMWARE_DATE    : std_logic_vector(31 downto 0) := x"20190228";
     constant C_FIRMWARE_MAJOR   : integer range 0 to 255        := 3;
     constant C_FIRMWARE_MINOR   : integer range 0 to 255        := 8;
-    constant C_FIRMWARE_BUILD   : integer range 0 to 255        := 0;
+    constant C_FIRMWARE_BUILD   : integer range 0 to 255        := 1;
     
     ------ Change log ------
     -- 1.8.6 no gbt sync procedure with oh
@@ -100,7 +100,8 @@ package gem_pkg is
     -- 3.7.0  Introduced MiniPOD links, and moved trigger inputs there, allowing to expand the number of OHs to 12
     -- 3.7.1  Made VFAT3 ADC0 and ADC1 reading async by returning a value from a local cache, and using a separate register to actually trigger the real read and update of the cache
     -- 3.7.2  Fixed a bug related to miniPOD links -- some config registers were missing, preventing the links from starting up correctly. Dummy trigger (EMTF) outputs added on miniPOD TX for easy loopback testing of the miniPOD trigger inputs
-    -- 3.8.0  Switched to the new OH FPGA communication protocol from Andrew, which uses 6b8b encoding and only one elink. Also added some GE2/1 support. 
+    -- 3.8.0  Switched to the new OH FPGA communication protocol from Andrew, which uses 6b8b encoding and only one elink. Also added some GE2/1 support.
+    -- 3.8.1  Bugfix in the OH FPGA communication FSM 
 
     --======================--
     --==      General     ==--

--- a/common/hdl/pkg/gem_pkg.vhd
+++ b/common/hdl/pkg/gem_pkg.vhd
@@ -10,10 +10,10 @@ package gem_pkg is
     --==  Firmware version  ==--
     --========================-- 
 
-    constant C_FIRMWARE_DATE    : std_logic_vector(31 downto 0) := x"20190127";
+    constant C_FIRMWARE_DATE    : std_logic_vector(31 downto 0) := x"20190415";
     constant C_FIRMWARE_MAJOR   : integer range 0 to 255        := 3;
     constant C_FIRMWARE_MINOR   : integer range 0 to 255        := 8;
-    constant C_FIRMWARE_BUILD   : integer range 0 to 255        := 0;
+    constant C_FIRMWARE_BUILD   : integer range 0 to 255        := 1;
     
     ------ Change log ------
     -- 1.8.6 no gbt sync procedure with oh
@@ -100,7 +100,8 @@ package gem_pkg is
     -- 3.7.0  Introduced MiniPOD links, and moved trigger inputs there, allowing to expand the number of OHs to 12
     -- 3.7.1  Made VFAT3 ADC0 and ADC1 reading async by returning a value from a local cache, and using a separate register to actually trigger the real read and update of the cache
     -- 3.7.2  Fixed a bug related to miniPOD links -- some config registers were missing, preventing the links from starting up correctly. Dummy trigger (EMTF) outputs added on miniPOD TX for easy loopback testing of the miniPOD trigger inputs
-    -- 3.8.0  Switched to the new OH FPGA communication protocol from Andrew, which uses 6b8b encoding and only one elink. Also added some GE2/1 support. 
+    -- 3.8.0  Switched to the new OH FPGA communication protocol from Andrew, which uses 6b8b encoding and only one elink. Also added some GE2/1 support.
+    -- 3.8.1  Added BC0 and RESYNC markers to the trigger receivers (backwards compatible with older OH fw versions). For now it's not doing anything with those, but just doesn't count them as errors. 
 
     --======================--
     --==      General     ==--

--- a/common/hdl/pkg/gem_pkg.vhd
+++ b/common/hdl/pkg/gem_pkg.vhd
@@ -10,10 +10,10 @@ package gem_pkg is
     --==  Firmware version  ==--
     --========================-- 
 
-    constant C_FIRMWARE_DATE    : std_logic_vector(31 downto 0) := x"20190415";
+    constant C_FIRMWARE_DATE    : std_logic_vector(31 downto 0) := x"20190508";
     constant C_FIRMWARE_MAJOR   : integer range 0 to 255        := 3;
     constant C_FIRMWARE_MINOR   : integer range 0 to 255        := 8;
-    constant C_FIRMWARE_BUILD   : integer range 0 to 255        := 2;
+    constant C_FIRMWARE_BUILD   : integer range 0 to 255        := 3;
     
     ------ Change log ------
     -- 1.8.6 no gbt sync procedure with oh
@@ -102,7 +102,8 @@ package gem_pkg is
     -- 3.7.2  Fixed a bug related to miniPOD links -- some config registers were missing, preventing the links from starting up correctly. Dummy trigger (EMTF) outputs added on miniPOD TX for easy loopback testing of the miniPOD trigger inputs
     -- 3.8.0  Switched to the new OH FPGA communication protocol from Andrew, which uses 6b8b encoding and only one elink. Also added some GE2/1 support.
     -- 3.8.1  Bugfix in the OH FPGA communication FSM 
-    -- 3.8.2  Added BC0 and RESYNC markers to the trigger receivers (backwards compatible with older OH fw versions). For now it's not doing anything with those, but just doesn't count them as errors. 
+    -- 3.8.2  Added BC0 and RESYNC markers to the trigger receivers (backwards compatible with older OH fw versions). For now it's not doing anything with those, but just doesn't count them as errors.
+    -- 3.8.3  Fixed the trigger link missed comma counter so that it starts counting errors after 128 clock cycles after reset (previously it would only start counting after the first occurance of good frame marker, which sometimes made a link look good even if it was completely bad) 
 
     --======================--
     --==      General     ==--

--- a/common/hdl/pkg/registers.vhd
+++ b/common/hdl/pkg/registers.vhd
@@ -9415,7 +9415,7 @@ package registers is
     constant REG_SLOW_CONTROL_SCA_ADC_MONITORING_MONITORING_OFF_ADDR    : std_logic_vector(16 downto 0) := '0' & x"2000";
     constant REG_SLOW_CONTROL_SCA_ADC_MONITORING_MONITORING_OFF_MSB    : integer := 31;
     constant REG_SLOW_CONTROL_SCA_ADC_MONITORING_MONITORING_OFF_LSB     : integer := 0;
-    constant REG_SLOW_CONTROL_SCA_ADC_MONITORING_MONITORING_OFF_DEFAULT : std_logic_vector(31 downto 0) := x"00000000";
+    constant REG_SLOW_CONTROL_SCA_ADC_MONITORING_MONITORING_OFF_DEFAULT : std_logic_vector(31 downto 0) := x"ffffffff";
 
     constant REG_SLOW_CONTROL_SCA_ADC_MONITORING_OH0_AVCCN_ADDR    : std_logic_vector(16 downto 0) := '0' & x"2001";
     constant REG_SLOW_CONTROL_SCA_ADC_MONITORING_OH0_AVCCN_MSB    : integer := 11;

--- a/scripts/address_table/gem_amc_top.xml
+++ b/scripts/address_table/gem_amc_top.xml
@@ -1070,7 +1070,7 @@
         <node id="ADC_MONITORING" address="0x2000">
           <node id="MONITORING_OFF" address="0x0" mask="0xffffffff" permission="rw"
                 description="Bits corresponding to each link if set to 1 will suspend ADC monitoring on that SCA"
-                fw_signal="sca_adc_monitor_off_arr" fw_default="0x00000000"/>
+                fw_signal="sca_adc_monitor_off_arr" fw_default="0xffffffff"/>
 
           <node id="OH${OH_IDX}" address="0x1"
                 description="ADC monitoring of Optohybrid ${OH_IDX}"
@@ -1566,6 +1566,73 @@
       </node>
 
     </node> <!-- end Config Blaster block -->
+
+    <!-- Optical links module -->
+    <node id="OPTICAL_LINKS"  address="0x1400000"
+          description="This module contains counters and control registers of all the optical links on the board (regardless of link rate or what they connect to)"
+          fw_is_module="true"
+          fw_is_module_external="true">
+
+      <node id="MGT_CHANNEL_${MGT}" address="0x0"
+            description="MGT channel ${MGT} control and status. Note: these are MGT channles, which do not correspond 1-to-1 with the fiber numbering. Please refer here for MGT channel to fiber mapping: https://docs.google.com/spreadsheets/d/1-AE7GeeU10GfLB-9FYOMN4k0-Z7bVkiQpLfXC4G2irI"
+            generate="true" generate_size="64" generate_address_step="0x00000040" generate_idx_var="MGT">
+
+        <node id="RESET" address="0x1" mask="0x00000003" permission="rw"
+              description="Writing 1 to bit 0 will trigger MGT TX channel reset, and writing 1 to bit 1 will trigger the MGT RX channel reset (write 3 to trigger both)">
+          <node id="TX_RESET" address="0x0" mask="0x00000001" permission="rw"
+                description="Writing 1 to this reg will trigger MGT TX channel reset"/>
+          <node id="RX_RESET" address="0x0" mask="0x00000002" permission="rw"
+                description="Writing 1 to this reg will trigger MGT RX channel reset"/>
+        </node>
+
+        <node id="CTRL" address="0x2" mask="0x0000007f" permission="rw"
+              description="This register exposes multiple MGT controls: bit 0 -- TX powerdown, bit 1 -- RX powerdown, bit 2 -- TX polarity, bit 3 -- RX polarity, bit 4 -- loopback, bit 5 -- TX inhibit, bit 6 -- RX low power mode enable">
+          <node id="TX_POWERDOWN" address="0x0" mask="0x00000001" permission="rw"
+                description="Setting this to 1 will powerdown the TX (writes 11 to TXPD), and 0 will put it in normal power mode (writes 00 to TXPD)"/>
+          <node id="RX_POWERDOWN" address="0x0" mask="0x00000002" permission="rw"
+                description="Setting this to 1 will powerdown the RX (writes 11 to RXPD), and 0 will put it in normal power mode (writes 00 to RXPD)"/>
+          <node id="TX_POLARITY" address="0x0" mask="0x00000004" permission="rw"
+                description="Setting this to 1 will invert the polarity of TX, setting to 0 will result in normal TX polarity"/>
+          <node id="RX_POLARITY" address="0x0" mask="0x00000008" permission="rw"
+                description="Setting this to 1 will invert the polarity of RX, setting to 0 will result in normal RX polarity"/>
+          <node id="LOOPBACK" address="0x0" mask="0x00000010" permission="rw"
+                description="Setting this to 1 will enable the near-end PMA loopback of the MGT (sets MGT LOOPBACK port to 010). This is an expert debug feature."/>
+          <node id="TX_INHIBIT" address="0x0" mask="0x00000020" permission="rw"
+                description="Setting this to 1 will inhibit the TX channel (forces MGTHTXP to 0 and MGTHTXN to 1). This is an expert debug feature."/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" mask="0x00000040" permission="rw"
+                description="Setting this to 1 enables the RX LPM (this controls RXLPMEN). NOTE: THIS MUST ALWAYS BE SET TO 1 FOR GOOD RX PERFORMANCE WITH 8b10b ENCODING."/>
+          <node id="RX_PRBS_SEL" address="0x1" mask="0x00000007" permission="rw"
+                description="Controls the RX PRBS mode: 000 -- normal operation (no PRBS checks), 001 -- PRBS7, 010 -- PRBS15, 011 -- PRBS23, 100 -- PRBS31"/>
+          <node id="TX_PRBS_SEL" address="0x1" mask="0x00000070" permission="rw"
+                description="Controls the TX PRBS mode: 000 -- normal operation (no PRBS), 001 -- PRBS7, 010 -- PRBS15, 011 -- PRBS23, 100 -- PRBS31, 101 -- PCIe compliance patteren, 110 -- square wave with 2 UI (alternating 0s and 1s), 111 -- square wave with 16 UI, 20 UI, 32 UI or 40 UI period depending on data width"/>
+          <node id="PRBS_CNT_RESET" address="0x2" mask="0x00000001" permission="w"
+                description="Writing 1 here resets the PRBS error counters"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" mask="0x00000001" permission="w"
+                description="Writing 1 here resets the RX error counters for this channel (not in table and disperr)"/>
+        </node>
+
+        <node id="STATUS" address="0x0" mask="0x0000000f" permission="r">
+          <node id="TX_RESET_DONE" address="0x0" mask="0x00000001" permission="r"
+                description="TX reset done signal"/>
+          <node id="RX_RESET_DONE" address="0x0" mask="0x00000002" permission="r"
+                description="RX reset done signal"/>
+          <node id="CPLL_LOCKED" address="0x0" mask="0x00000004" permission="r"
+                description="CPLL locked signal"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" mask="0x00000008" permission="r"
+                description="CPLL reference clock is lost if this is 1"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r"
+                description="PRBS error counter"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r"
+                description="PRBS error counter"/>
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r"
+                description="RX not-in-table counter"/>
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r"
+                description="RX disparity error counter"/>
+        </node>
+
+      </node>
+
+    </node> <!--End of optical links module -->
 
     <node id="GLIB_SYSTEM" address="0x910000"
           description="Legacy system registers (taken from GLIB system core).

--- a/scripts/address_table/uhal_gem_amc_ctp7_amc.xml
+++ b/scripts/address_table/uhal_gem_amc_ctp7_amc.xml
@@ -493,9 +493,6 @@
         <node id="USE_OH_VFAT3_SLOTS" address="0x1" permission="rw" mask="0x1"/>
         <node id="SC_ONLY_MODE" address="0x1" permission="rw" mask="0x2"/>
         <node id="USE_OH_V3B_MAPPING" address="0x1" permission="rw" mask="0x4"/>
-        <node id="V3B_FPGA_SLOW_RX_BITSHIFT" address="0x1" permission="rw" mask="0x70"/>
-        <node id="V3B_FPGA_TX_0_BITSLIP" address="0x1" permission="rw" mask="0xf00"/>
-        <node id="V3B_FPGA_TX_1_BITSLIP" address="0x1" permission="rw" mask="0xf000"/>
       </node>
       <node id="TESTS" address="0x200" >
         <node id="GBT_LOOPBACK_EN" address="0x0" permission="rw" mask="0x1"/>
@@ -570,6 +567,126 @@
           <node id="ERROR_CNT" address="0x2" permission="r" />
         </node>
         <node id="LINK_11" address="0xc0" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_12" address="0xd0" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_13" address="0xe0" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_14" address="0xf0" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_15" address="0x100" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_16" address="0x110" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_17" address="0x120" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_18" address="0x130" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_19" address="0x140" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_20" address="0x150" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_21" address="0x160" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_22" address="0x170" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_23" address="0x180" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_24" address="0x190" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_25" address="0x1a0" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_26" address="0x1b0" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_27" address="0x1c0" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_28" address="0x1d0" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_29" address="0x1e0" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_30" address="0x1f0" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_31" address="0x200" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_32" address="0x210" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_33" address="0x220" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_34" address="0x230" >
+          <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
+          <node id="ERROR_CNT" address="0x2" permission="r" />
+        </node>
+        <node id="LINK_35" address="0x240" >
           <node id="SYNC_DONE" address="0x0" permission="r" mask="0x1"/>
           <node id="MEGA_WORD_CNT" address="0x1" permission="r" />
           <node id="ERROR_CNT" address="0x2" permission="r" />
@@ -3681,6 +3798,1864 @@
         <node id="OH_FPGA_OH9" address="0x20708" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH10" address="0x207d0" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH11" address="0x20898" permission="rw" mode="block"size="200"/>
+      </node>
+    </node>
+    <node id="OPTICAL_LINKS" address="0x1400000" >
+      <node id="MGT_CHANNEL_0" address="0x0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_1" address="0x40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_2" address="0x80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_3" address="0xc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_4" address="0x100" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_5" address="0x140" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_6" address="0x180" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_7" address="0x1c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_8" address="0x200" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_9" address="0x240" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_10" address="0x280" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_11" address="0x2c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_12" address="0x300" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_13" address="0x340" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_14" address="0x380" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_15" address="0x3c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_16" address="0x400" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_17" address="0x440" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_18" address="0x480" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_19" address="0x4c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_20" address="0x500" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_21" address="0x540" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_22" address="0x580" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_23" address="0x5c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_24" address="0x600" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_25" address="0x640" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_26" address="0x680" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_27" address="0x6c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_28" address="0x700" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_29" address="0x740" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_30" address="0x780" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_31" address="0x7c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_32" address="0x800" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_33" address="0x840" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_34" address="0x880" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_35" address="0x8c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_36" address="0x900" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_37" address="0x940" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_38" address="0x980" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_39" address="0x9c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_40" address="0xa00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_41" address="0xa40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_42" address="0xa80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_43" address="0xac0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_44" address="0xb00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_45" address="0xb40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_46" address="0xb80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_47" address="0xbc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_48" address="0xc00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_49" address="0xc40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_50" address="0xc80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_51" address="0xcc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_52" address="0xd00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_53" address="0xd40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_54" address="0xd80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_55" address="0xdc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_56" address="0xe00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_57" address="0xe40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_58" address="0xe80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_59" address="0xec0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_60" address="0xf00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_61" address="0xf40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_62" address="0xf80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_63" address="0xfc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
       </node>
     </node>
     <node id="GLIB_SYSTEM" address="0x910000" >

--- a/scripts/address_table/uhal_gem_amc_ctp7_link00.xml
+++ b/scripts/address_table/uhal_gem_amc_ctp7_link00.xml
@@ -1649,8 +1649,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT1" address="0x800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -2749,8 +2751,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT2" address="0x1000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -3849,8 +3853,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT3" address="0x1800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -4949,8 +4955,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT4" address="0x2000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -6049,8 +6057,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT5" address="0x2800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -7149,8 +7159,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT6" address="0x3000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -8249,8 +8261,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT7" address="0x3800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -9349,8 +9363,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT8" address="0x4000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -10449,8 +10465,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT9" address="0x4800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -11549,8 +11567,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT10" address="0x5000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -12649,8 +12669,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT11" address="0x5800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -13749,8 +13771,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT12" address="0x6000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -14849,8 +14873,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT13" address="0x6800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -15949,8 +15975,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT14" address="0x7000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -17049,8 +17077,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT15" address="0x7800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -18149,8 +18179,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT16" address="0x8000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -19249,8 +19281,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT17" address="0x8800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -20349,8 +20383,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT18" address="0x9000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -21449,8 +21485,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT19" address="0x9800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -22549,8 +22587,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT20" address="0xa000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -23649,8 +23689,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT21" address="0xa800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -24749,8 +24791,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT22" address="0xb000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -25849,8 +25893,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT23" address="0xb800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -26949,8 +26995,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
         </node>
       </node>
@@ -27004,6 +27052,1864 @@
         <node id="OH_FPGA_OH9" address="0x20708" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH10" address="0x207d0" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH11" address="0x20898" permission="rw" mode="block"size="200"/>
+      </node>
+    </node>
+    <node id="OPTICAL_LINKS" address="0x1400000" >
+      <node id="MGT_CHANNEL_0" address="0x0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_1" address="0x40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_2" address="0x80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_3" address="0xc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_4" address="0x100" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_5" address="0x140" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_6" address="0x180" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_7" address="0x1c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_8" address="0x200" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_9" address="0x240" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_10" address="0x280" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_11" address="0x2c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_12" address="0x300" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_13" address="0x340" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_14" address="0x380" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_15" address="0x3c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_16" address="0x400" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_17" address="0x440" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_18" address="0x480" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_19" address="0x4c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_20" address="0x500" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_21" address="0x540" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_22" address="0x580" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_23" address="0x5c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_24" address="0x600" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_25" address="0x640" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_26" address="0x680" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_27" address="0x6c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_28" address="0x700" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_29" address="0x740" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_30" address="0x780" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_31" address="0x7c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_32" address="0x800" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_33" address="0x840" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_34" address="0x880" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_35" address="0x8c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_36" address="0x900" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_37" address="0x940" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_38" address="0x980" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_39" address="0x9c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_40" address="0xa00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_41" address="0xa40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_42" address="0xa80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_43" address="0xac0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_44" address="0xb00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_45" address="0xb40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_46" address="0xb80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_47" address="0xbc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_48" address="0xc00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_49" address="0xc40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_50" address="0xc80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_51" address="0xcc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_52" address="0xd00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_53" address="0xd40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_54" address="0xd80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_55" address="0xdc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_56" address="0xe00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_57" address="0xe40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_58" address="0xe80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_59" address="0xec0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_60" address="0xf00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_61" address="0xf40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_62" address="0xf80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_63" address="0xfc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
       </node>
     </node>
   </node>

--- a/scripts/address_table/uhal_gem_amc_ctp7_link01.xml
+++ b/scripts/address_table/uhal_gem_amc_ctp7_link01.xml
@@ -1649,8 +1649,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT1" address="0x800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -2749,8 +2751,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT2" address="0x1000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -3849,8 +3853,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT3" address="0x1800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -4949,8 +4955,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT4" address="0x2000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -6049,8 +6057,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT5" address="0x2800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -7149,8 +7159,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT6" address="0x3000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -8249,8 +8261,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT7" address="0x3800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -9349,8 +9363,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT8" address="0x4000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -10449,8 +10465,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT9" address="0x4800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -11549,8 +11567,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT10" address="0x5000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -12649,8 +12669,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT11" address="0x5800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -13749,8 +13771,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT12" address="0x6000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -14849,8 +14873,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT13" address="0x6800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -15949,8 +15975,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT14" address="0x7000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -17049,8 +17077,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT15" address="0x7800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -18149,8 +18179,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT16" address="0x8000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -19249,8 +19281,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT17" address="0x8800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -20349,8 +20383,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT18" address="0x9000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -21449,8 +21485,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT19" address="0x9800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -22549,8 +22587,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT20" address="0xa000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -23649,8 +23689,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT21" address="0xa800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -24749,8 +24791,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT22" address="0xb000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -25849,8 +25893,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT23" address="0xb800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -26949,8 +26995,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
         </node>
       </node>
@@ -27004,6 +27052,1864 @@
         <node id="OH_FPGA_OH9" address="0x20708" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH10" address="0x207d0" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH11" address="0x20898" permission="rw" mode="block"size="200"/>
+      </node>
+    </node>
+    <node id="OPTICAL_LINKS" address="0x1400000" >
+      <node id="MGT_CHANNEL_0" address="0x0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_1" address="0x40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_2" address="0x80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_3" address="0xc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_4" address="0x100" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_5" address="0x140" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_6" address="0x180" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_7" address="0x1c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_8" address="0x200" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_9" address="0x240" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_10" address="0x280" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_11" address="0x2c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_12" address="0x300" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_13" address="0x340" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_14" address="0x380" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_15" address="0x3c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_16" address="0x400" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_17" address="0x440" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_18" address="0x480" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_19" address="0x4c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_20" address="0x500" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_21" address="0x540" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_22" address="0x580" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_23" address="0x5c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_24" address="0x600" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_25" address="0x640" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_26" address="0x680" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_27" address="0x6c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_28" address="0x700" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_29" address="0x740" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_30" address="0x780" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_31" address="0x7c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_32" address="0x800" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_33" address="0x840" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_34" address="0x880" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_35" address="0x8c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_36" address="0x900" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_37" address="0x940" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_38" address="0x980" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_39" address="0x9c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_40" address="0xa00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_41" address="0xa40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_42" address="0xa80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_43" address="0xac0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_44" address="0xb00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_45" address="0xb40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_46" address="0xb80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_47" address="0xbc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_48" address="0xc00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_49" address="0xc40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_50" address="0xc80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_51" address="0xcc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_52" address="0xd00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_53" address="0xd40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_54" address="0xd80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_55" address="0xdc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_56" address="0xe00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_57" address="0xe40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_58" address="0xe80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_59" address="0xec0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_60" address="0xf00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_61" address="0xf40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_62" address="0xf80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_63" address="0xfc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
       </node>
     </node>
   </node>

--- a/scripts/address_table/uhal_gem_amc_ctp7_link02.xml
+++ b/scripts/address_table/uhal_gem_amc_ctp7_link02.xml
@@ -1649,8 +1649,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT1" address="0x800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -2749,8 +2751,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT2" address="0x1000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -3849,8 +3853,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT3" address="0x1800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -4949,8 +4955,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT4" address="0x2000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -6049,8 +6057,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT5" address="0x2800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -7149,8 +7159,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT6" address="0x3000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -8249,8 +8261,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT7" address="0x3800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -9349,8 +9363,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT8" address="0x4000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -10449,8 +10465,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT9" address="0x4800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -11549,8 +11567,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT10" address="0x5000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -12649,8 +12669,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT11" address="0x5800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -13749,8 +13771,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT12" address="0x6000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -14849,8 +14873,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT13" address="0x6800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -15949,8 +15975,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT14" address="0x7000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -17049,8 +17077,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT15" address="0x7800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -18149,8 +18179,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT16" address="0x8000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -19249,8 +19281,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT17" address="0x8800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -20349,8 +20383,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT18" address="0x9000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -21449,8 +21485,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT19" address="0x9800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -22549,8 +22587,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT20" address="0xa000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -23649,8 +23689,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT21" address="0xa800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -24749,8 +24791,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT22" address="0xb000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -25849,8 +25893,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT23" address="0xb800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -26949,8 +26995,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
         </node>
       </node>
@@ -27004,6 +27052,1864 @@
         <node id="OH_FPGA_OH9" address="0x20708" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH10" address="0x207d0" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH11" address="0x20898" permission="rw" mode="block"size="200"/>
+      </node>
+    </node>
+    <node id="OPTICAL_LINKS" address="0x1400000" >
+      <node id="MGT_CHANNEL_0" address="0x0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_1" address="0x40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_2" address="0x80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_3" address="0xc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_4" address="0x100" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_5" address="0x140" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_6" address="0x180" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_7" address="0x1c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_8" address="0x200" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_9" address="0x240" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_10" address="0x280" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_11" address="0x2c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_12" address="0x300" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_13" address="0x340" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_14" address="0x380" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_15" address="0x3c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_16" address="0x400" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_17" address="0x440" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_18" address="0x480" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_19" address="0x4c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_20" address="0x500" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_21" address="0x540" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_22" address="0x580" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_23" address="0x5c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_24" address="0x600" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_25" address="0x640" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_26" address="0x680" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_27" address="0x6c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_28" address="0x700" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_29" address="0x740" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_30" address="0x780" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_31" address="0x7c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_32" address="0x800" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_33" address="0x840" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_34" address="0x880" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_35" address="0x8c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_36" address="0x900" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_37" address="0x940" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_38" address="0x980" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_39" address="0x9c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_40" address="0xa00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_41" address="0xa40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_42" address="0xa80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_43" address="0xac0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_44" address="0xb00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_45" address="0xb40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_46" address="0xb80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_47" address="0xbc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_48" address="0xc00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_49" address="0xc40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_50" address="0xc80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_51" address="0xcc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_52" address="0xd00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_53" address="0xd40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_54" address="0xd80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_55" address="0xdc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_56" address="0xe00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_57" address="0xe40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_58" address="0xe80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_59" address="0xec0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_60" address="0xf00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_61" address="0xf40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_62" address="0xf80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_63" address="0xfc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
       </node>
     </node>
   </node>

--- a/scripts/address_table/uhal_gem_amc_ctp7_link03.xml
+++ b/scripts/address_table/uhal_gem_amc_ctp7_link03.xml
@@ -1649,8 +1649,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT1" address="0x800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -2749,8 +2751,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT2" address="0x1000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -3849,8 +3853,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT3" address="0x1800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -4949,8 +4955,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT4" address="0x2000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -6049,8 +6057,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT5" address="0x2800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -7149,8 +7159,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT6" address="0x3000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -8249,8 +8261,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT7" address="0x3800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -9349,8 +9363,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT8" address="0x4000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -10449,8 +10465,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT9" address="0x4800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -11549,8 +11567,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT10" address="0x5000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -12649,8 +12669,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT11" address="0x5800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -13749,8 +13771,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT12" address="0x6000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -14849,8 +14873,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT13" address="0x6800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -15949,8 +15975,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT14" address="0x7000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -17049,8 +17077,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT15" address="0x7800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -18149,8 +18179,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT16" address="0x8000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -19249,8 +19281,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT17" address="0x8800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -20349,8 +20383,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT18" address="0x9000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -21449,8 +21485,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT19" address="0x9800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -22549,8 +22587,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT20" address="0xa000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -23649,8 +23689,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT21" address="0xa800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -24749,8 +24791,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT22" address="0xb000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -25849,8 +25893,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT23" address="0xb800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -26949,8 +26995,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
         </node>
       </node>
@@ -27004,6 +27052,1864 @@
         <node id="OH_FPGA_OH9" address="0x20708" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH10" address="0x207d0" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH11" address="0x20898" permission="rw" mode="block"size="200"/>
+      </node>
+    </node>
+    <node id="OPTICAL_LINKS" address="0x1400000" >
+      <node id="MGT_CHANNEL_0" address="0x0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_1" address="0x40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_2" address="0x80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_3" address="0xc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_4" address="0x100" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_5" address="0x140" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_6" address="0x180" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_7" address="0x1c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_8" address="0x200" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_9" address="0x240" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_10" address="0x280" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_11" address="0x2c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_12" address="0x300" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_13" address="0x340" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_14" address="0x380" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_15" address="0x3c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_16" address="0x400" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_17" address="0x440" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_18" address="0x480" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_19" address="0x4c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_20" address="0x500" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_21" address="0x540" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_22" address="0x580" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_23" address="0x5c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_24" address="0x600" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_25" address="0x640" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_26" address="0x680" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_27" address="0x6c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_28" address="0x700" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_29" address="0x740" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_30" address="0x780" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_31" address="0x7c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_32" address="0x800" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_33" address="0x840" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_34" address="0x880" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_35" address="0x8c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_36" address="0x900" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_37" address="0x940" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_38" address="0x980" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_39" address="0x9c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_40" address="0xa00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_41" address="0xa40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_42" address="0xa80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_43" address="0xac0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_44" address="0xb00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_45" address="0xb40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_46" address="0xb80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_47" address="0xbc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_48" address="0xc00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_49" address="0xc40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_50" address="0xc80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_51" address="0xcc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_52" address="0xd00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_53" address="0xd40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_54" address="0xd80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_55" address="0xdc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_56" address="0xe00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_57" address="0xe40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_58" address="0xe80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_59" address="0xec0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_60" address="0xf00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_61" address="0xf40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_62" address="0xf80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_63" address="0xfc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
       </node>
     </node>
   </node>

--- a/scripts/address_table/uhal_gem_amc_ctp7_link04.xml
+++ b/scripts/address_table/uhal_gem_amc_ctp7_link04.xml
@@ -1649,8 +1649,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT1" address="0x800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -2749,8 +2751,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT2" address="0x1000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -3849,8 +3853,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT3" address="0x1800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -4949,8 +4955,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT4" address="0x2000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -6049,8 +6057,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT5" address="0x2800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -7149,8 +7159,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT6" address="0x3000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -8249,8 +8261,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT7" address="0x3800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -9349,8 +9363,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT8" address="0x4000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -10449,8 +10465,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT9" address="0x4800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -11549,8 +11567,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT10" address="0x5000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -12649,8 +12669,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT11" address="0x5800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -13749,8 +13771,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT12" address="0x6000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -14849,8 +14873,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT13" address="0x6800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -15949,8 +15975,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT14" address="0x7000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -17049,8 +17077,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT15" address="0x7800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -18149,8 +18179,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT16" address="0x8000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -19249,8 +19281,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT17" address="0x8800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -20349,8 +20383,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT18" address="0x9000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -21449,8 +21485,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT19" address="0x9800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -22549,8 +22587,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT20" address="0xa000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -23649,8 +23689,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT21" address="0xa800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -24749,8 +24791,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT22" address="0xb000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -25849,8 +25893,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT23" address="0xb800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -26949,8 +26995,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
         </node>
       </node>
@@ -27004,6 +27052,1864 @@
         <node id="OH_FPGA_OH9" address="0x20708" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH10" address="0x207d0" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH11" address="0x20898" permission="rw" mode="block"size="200"/>
+      </node>
+    </node>
+    <node id="OPTICAL_LINKS" address="0x1400000" >
+      <node id="MGT_CHANNEL_0" address="0x0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_1" address="0x40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_2" address="0x80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_3" address="0xc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_4" address="0x100" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_5" address="0x140" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_6" address="0x180" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_7" address="0x1c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_8" address="0x200" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_9" address="0x240" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_10" address="0x280" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_11" address="0x2c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_12" address="0x300" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_13" address="0x340" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_14" address="0x380" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_15" address="0x3c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_16" address="0x400" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_17" address="0x440" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_18" address="0x480" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_19" address="0x4c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_20" address="0x500" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_21" address="0x540" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_22" address="0x580" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_23" address="0x5c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_24" address="0x600" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_25" address="0x640" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_26" address="0x680" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_27" address="0x6c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_28" address="0x700" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_29" address="0x740" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_30" address="0x780" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_31" address="0x7c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_32" address="0x800" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_33" address="0x840" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_34" address="0x880" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_35" address="0x8c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_36" address="0x900" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_37" address="0x940" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_38" address="0x980" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_39" address="0x9c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_40" address="0xa00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_41" address="0xa40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_42" address="0xa80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_43" address="0xac0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_44" address="0xb00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_45" address="0xb40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_46" address="0xb80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_47" address="0xbc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_48" address="0xc00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_49" address="0xc40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_50" address="0xc80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_51" address="0xcc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_52" address="0xd00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_53" address="0xd40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_54" address="0xd80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_55" address="0xdc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_56" address="0xe00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_57" address="0xe40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_58" address="0xe80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_59" address="0xec0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_60" address="0xf00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_61" address="0xf40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_62" address="0xf80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_63" address="0xfc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
       </node>
     </node>
   </node>

--- a/scripts/address_table/uhal_gem_amc_ctp7_link05.xml
+++ b/scripts/address_table/uhal_gem_amc_ctp7_link05.xml
@@ -1649,8 +1649,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT1" address="0x800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -2749,8 +2751,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT2" address="0x1000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -3849,8 +3853,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT3" address="0x1800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -4949,8 +4955,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT4" address="0x2000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -6049,8 +6057,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT5" address="0x2800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -7149,8 +7159,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT6" address="0x3000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -8249,8 +8261,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT7" address="0x3800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -9349,8 +9363,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT8" address="0x4000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -10449,8 +10465,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT9" address="0x4800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -11549,8 +11567,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT10" address="0x5000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -12649,8 +12669,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT11" address="0x5800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -13749,8 +13771,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT12" address="0x6000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -14849,8 +14873,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT13" address="0x6800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -15949,8 +15975,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT14" address="0x7000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -17049,8 +17077,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT15" address="0x7800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -18149,8 +18179,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT16" address="0x8000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -19249,8 +19281,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT17" address="0x8800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -20349,8 +20383,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT18" address="0x9000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -21449,8 +21485,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT19" address="0x9800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -22549,8 +22587,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT20" address="0xa000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -23649,8 +23689,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT21" address="0xa800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -24749,8 +24791,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT22" address="0xb000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -25849,8 +25893,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT23" address="0xb800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -26949,8 +26995,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
         </node>
       </node>
@@ -27004,6 +27052,1864 @@
         <node id="OH_FPGA_OH9" address="0x20708" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH10" address="0x207d0" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH11" address="0x20898" permission="rw" mode="block"size="200"/>
+      </node>
+    </node>
+    <node id="OPTICAL_LINKS" address="0x1400000" >
+      <node id="MGT_CHANNEL_0" address="0x0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_1" address="0x40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_2" address="0x80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_3" address="0xc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_4" address="0x100" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_5" address="0x140" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_6" address="0x180" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_7" address="0x1c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_8" address="0x200" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_9" address="0x240" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_10" address="0x280" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_11" address="0x2c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_12" address="0x300" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_13" address="0x340" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_14" address="0x380" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_15" address="0x3c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_16" address="0x400" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_17" address="0x440" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_18" address="0x480" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_19" address="0x4c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_20" address="0x500" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_21" address="0x540" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_22" address="0x580" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_23" address="0x5c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_24" address="0x600" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_25" address="0x640" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_26" address="0x680" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_27" address="0x6c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_28" address="0x700" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_29" address="0x740" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_30" address="0x780" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_31" address="0x7c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_32" address="0x800" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_33" address="0x840" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_34" address="0x880" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_35" address="0x8c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_36" address="0x900" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_37" address="0x940" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_38" address="0x980" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_39" address="0x9c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_40" address="0xa00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_41" address="0xa40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_42" address="0xa80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_43" address="0xac0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_44" address="0xb00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_45" address="0xb40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_46" address="0xb80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_47" address="0xbc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_48" address="0xc00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_49" address="0xc40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_50" address="0xc80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_51" address="0xcc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_52" address="0xd00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_53" address="0xd40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_54" address="0xd80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_55" address="0xdc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_56" address="0xe00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_57" address="0xe40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_58" address="0xe80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_59" address="0xec0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_60" address="0xf00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_61" address="0xf40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_62" address="0xf80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_63" address="0xfc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
       </node>
     </node>
   </node>

--- a/scripts/address_table/uhal_gem_amc_ctp7_link06.xml
+++ b/scripts/address_table/uhal_gem_amc_ctp7_link06.xml
@@ -1649,8 +1649,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT1" address="0x800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -2749,8 +2751,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT2" address="0x1000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -3849,8 +3853,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT3" address="0x1800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -4949,8 +4955,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT4" address="0x2000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -6049,8 +6057,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT5" address="0x2800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -7149,8 +7159,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT6" address="0x3000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -8249,8 +8261,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT7" address="0x3800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -9349,8 +9363,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT8" address="0x4000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -10449,8 +10465,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT9" address="0x4800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -11549,8 +11567,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT10" address="0x5000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -12649,8 +12669,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT11" address="0x5800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -13749,8 +13771,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT12" address="0x6000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -14849,8 +14873,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT13" address="0x6800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -15949,8 +15975,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT14" address="0x7000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -17049,8 +17077,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT15" address="0x7800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -18149,8 +18179,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT16" address="0x8000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -19249,8 +19281,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT17" address="0x8800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -20349,8 +20383,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT18" address="0x9000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -21449,8 +21485,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT19" address="0x9800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -22549,8 +22587,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT20" address="0xa000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -23649,8 +23689,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT21" address="0xa800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -24749,8 +24791,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT22" address="0xb000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -25849,8 +25893,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT23" address="0xb800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -26949,8 +26995,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
         </node>
       </node>
@@ -27004,6 +27052,1864 @@
         <node id="OH_FPGA_OH9" address="0x20708" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH10" address="0x207d0" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH11" address="0x20898" permission="rw" mode="block"size="200"/>
+      </node>
+    </node>
+    <node id="OPTICAL_LINKS" address="0x1400000" >
+      <node id="MGT_CHANNEL_0" address="0x0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_1" address="0x40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_2" address="0x80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_3" address="0xc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_4" address="0x100" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_5" address="0x140" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_6" address="0x180" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_7" address="0x1c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_8" address="0x200" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_9" address="0x240" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_10" address="0x280" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_11" address="0x2c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_12" address="0x300" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_13" address="0x340" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_14" address="0x380" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_15" address="0x3c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_16" address="0x400" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_17" address="0x440" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_18" address="0x480" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_19" address="0x4c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_20" address="0x500" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_21" address="0x540" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_22" address="0x580" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_23" address="0x5c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_24" address="0x600" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_25" address="0x640" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_26" address="0x680" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_27" address="0x6c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_28" address="0x700" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_29" address="0x740" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_30" address="0x780" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_31" address="0x7c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_32" address="0x800" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_33" address="0x840" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_34" address="0x880" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_35" address="0x8c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_36" address="0x900" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_37" address="0x940" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_38" address="0x980" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_39" address="0x9c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_40" address="0xa00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_41" address="0xa40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_42" address="0xa80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_43" address="0xac0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_44" address="0xb00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_45" address="0xb40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_46" address="0xb80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_47" address="0xbc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_48" address="0xc00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_49" address="0xc40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_50" address="0xc80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_51" address="0xcc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_52" address="0xd00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_53" address="0xd40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_54" address="0xd80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_55" address="0xdc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_56" address="0xe00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_57" address="0xe40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_58" address="0xe80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_59" address="0xec0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_60" address="0xf00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_61" address="0xf40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_62" address="0xf80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_63" address="0xfc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
       </node>
     </node>
   </node>

--- a/scripts/address_table/uhal_gem_amc_ctp7_link07.xml
+++ b/scripts/address_table/uhal_gem_amc_ctp7_link07.xml
@@ -1649,8 +1649,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT1" address="0x800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -2749,8 +2751,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT2" address="0x1000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -3849,8 +3853,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT3" address="0x1800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -4949,8 +4955,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT4" address="0x2000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -6049,8 +6057,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT5" address="0x2800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -7149,8 +7159,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT6" address="0x3000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -8249,8 +8261,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT7" address="0x3800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -9349,8 +9363,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT8" address="0x4000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -10449,8 +10465,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT9" address="0x4800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -11549,8 +11567,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT10" address="0x5000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -12649,8 +12669,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT11" address="0x5800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -13749,8 +13771,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT12" address="0x6000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -14849,8 +14873,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT13" address="0x6800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -15949,8 +15975,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT14" address="0x7000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -17049,8 +17077,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT15" address="0x7800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -18149,8 +18179,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT16" address="0x8000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -19249,8 +19281,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT17" address="0x8800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -20349,8 +20383,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT18" address="0x9000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -21449,8 +21485,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT19" address="0x9800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -22549,8 +22587,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT20" address="0xa000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -23649,8 +23689,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT21" address="0xa800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -24749,8 +24791,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT22" address="0xb000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -25849,8 +25893,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT23" address="0xb800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -26949,8 +26995,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
         </node>
       </node>
@@ -27004,6 +27052,1864 @@
         <node id="OH_FPGA_OH9" address="0x20708" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH10" address="0x207d0" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH11" address="0x20898" permission="rw" mode="block"size="200"/>
+      </node>
+    </node>
+    <node id="OPTICAL_LINKS" address="0x1400000" >
+      <node id="MGT_CHANNEL_0" address="0x0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_1" address="0x40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_2" address="0x80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_3" address="0xc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_4" address="0x100" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_5" address="0x140" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_6" address="0x180" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_7" address="0x1c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_8" address="0x200" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_9" address="0x240" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_10" address="0x280" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_11" address="0x2c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_12" address="0x300" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_13" address="0x340" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_14" address="0x380" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_15" address="0x3c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_16" address="0x400" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_17" address="0x440" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_18" address="0x480" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_19" address="0x4c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_20" address="0x500" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_21" address="0x540" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_22" address="0x580" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_23" address="0x5c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_24" address="0x600" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_25" address="0x640" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_26" address="0x680" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_27" address="0x6c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_28" address="0x700" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_29" address="0x740" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_30" address="0x780" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_31" address="0x7c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_32" address="0x800" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_33" address="0x840" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_34" address="0x880" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_35" address="0x8c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_36" address="0x900" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_37" address="0x940" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_38" address="0x980" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_39" address="0x9c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_40" address="0xa00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_41" address="0xa40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_42" address="0xa80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_43" address="0xac0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_44" address="0xb00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_45" address="0xb40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_46" address="0xb80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_47" address="0xbc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_48" address="0xc00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_49" address="0xc40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_50" address="0xc80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_51" address="0xcc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_52" address="0xd00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_53" address="0xd40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_54" address="0xd80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_55" address="0xdc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_56" address="0xe00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_57" address="0xe40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_58" address="0xe80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_59" address="0xec0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_60" address="0xf00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_61" address="0xf40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_62" address="0xf80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_63" address="0xfc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
       </node>
     </node>
   </node>

--- a/scripts/address_table/uhal_gem_amc_ctp7_link08.xml
+++ b/scripts/address_table/uhal_gem_amc_ctp7_link08.xml
@@ -1649,8 +1649,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT1" address="0x800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -2749,8 +2751,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT2" address="0x1000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -3849,8 +3853,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT3" address="0x1800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -4949,8 +4955,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT4" address="0x2000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -6049,8 +6057,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT5" address="0x2800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -7149,8 +7159,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT6" address="0x3000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -8249,8 +8261,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT7" address="0x3800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -9349,8 +9363,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT8" address="0x4000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -10449,8 +10465,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT9" address="0x4800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -11549,8 +11567,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT10" address="0x5000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -12649,8 +12669,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT11" address="0x5800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -13749,8 +13771,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT12" address="0x6000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -14849,8 +14873,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT13" address="0x6800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -15949,8 +15975,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT14" address="0x7000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -17049,8 +17077,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT15" address="0x7800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -18149,8 +18179,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT16" address="0x8000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -19249,8 +19281,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT17" address="0x8800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -20349,8 +20383,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT18" address="0x9000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -21449,8 +21485,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT19" address="0x9800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -22549,8 +22587,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT20" address="0xa000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -23649,8 +23689,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT21" address="0xa800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -24749,8 +24791,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT22" address="0xb000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -25849,8 +25893,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT23" address="0xb800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -26949,8 +26995,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
         </node>
       </node>
@@ -27004,6 +27052,1864 @@
         <node id="OH_FPGA_OH9" address="0x20708" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH10" address="0x207d0" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH11" address="0x20898" permission="rw" mode="block"size="200"/>
+      </node>
+    </node>
+    <node id="OPTICAL_LINKS" address="0x1400000" >
+      <node id="MGT_CHANNEL_0" address="0x0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_1" address="0x40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_2" address="0x80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_3" address="0xc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_4" address="0x100" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_5" address="0x140" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_6" address="0x180" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_7" address="0x1c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_8" address="0x200" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_9" address="0x240" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_10" address="0x280" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_11" address="0x2c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_12" address="0x300" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_13" address="0x340" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_14" address="0x380" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_15" address="0x3c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_16" address="0x400" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_17" address="0x440" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_18" address="0x480" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_19" address="0x4c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_20" address="0x500" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_21" address="0x540" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_22" address="0x580" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_23" address="0x5c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_24" address="0x600" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_25" address="0x640" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_26" address="0x680" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_27" address="0x6c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_28" address="0x700" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_29" address="0x740" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_30" address="0x780" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_31" address="0x7c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_32" address="0x800" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_33" address="0x840" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_34" address="0x880" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_35" address="0x8c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_36" address="0x900" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_37" address="0x940" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_38" address="0x980" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_39" address="0x9c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_40" address="0xa00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_41" address="0xa40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_42" address="0xa80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_43" address="0xac0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_44" address="0xb00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_45" address="0xb40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_46" address="0xb80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_47" address="0xbc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_48" address="0xc00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_49" address="0xc40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_50" address="0xc80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_51" address="0xcc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_52" address="0xd00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_53" address="0xd40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_54" address="0xd80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_55" address="0xdc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_56" address="0xe00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_57" address="0xe40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_58" address="0xe80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_59" address="0xec0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_60" address="0xf00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_61" address="0xf40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_62" address="0xf80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_63" address="0xfc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
       </node>
     </node>
   </node>

--- a/scripts/address_table/uhal_gem_amc_ctp7_link09.xml
+++ b/scripts/address_table/uhal_gem_amc_ctp7_link09.xml
@@ -1649,8 +1649,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT1" address="0x800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -2749,8 +2751,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT2" address="0x1000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -3849,8 +3853,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT3" address="0x1800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -4949,8 +4955,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT4" address="0x2000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -6049,8 +6057,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT5" address="0x2800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -7149,8 +7159,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT6" address="0x3000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -8249,8 +8261,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT7" address="0x3800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -9349,8 +9363,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT8" address="0x4000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -10449,8 +10465,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT9" address="0x4800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -11549,8 +11567,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT10" address="0x5000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -12649,8 +12669,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT11" address="0x5800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -13749,8 +13771,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT12" address="0x6000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -14849,8 +14873,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT13" address="0x6800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -15949,8 +15975,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT14" address="0x7000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -17049,8 +17077,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT15" address="0x7800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -18149,8 +18179,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT16" address="0x8000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -19249,8 +19281,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT17" address="0x8800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -20349,8 +20383,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT18" address="0x9000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -21449,8 +21485,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT19" address="0x9800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -22549,8 +22587,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT20" address="0xa000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -23649,8 +23689,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT21" address="0xa800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -24749,8 +24791,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT22" address="0xb000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -25849,8 +25893,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT23" address="0xb800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -26949,8 +26995,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
         </node>
       </node>
@@ -27004,6 +27052,1864 @@
         <node id="OH_FPGA_OH9" address="0x20708" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH10" address="0x207d0" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH11" address="0x20898" permission="rw" mode="block"size="200"/>
+      </node>
+    </node>
+    <node id="OPTICAL_LINKS" address="0x1400000" >
+      <node id="MGT_CHANNEL_0" address="0x0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_1" address="0x40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_2" address="0x80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_3" address="0xc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_4" address="0x100" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_5" address="0x140" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_6" address="0x180" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_7" address="0x1c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_8" address="0x200" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_9" address="0x240" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_10" address="0x280" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_11" address="0x2c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_12" address="0x300" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_13" address="0x340" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_14" address="0x380" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_15" address="0x3c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_16" address="0x400" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_17" address="0x440" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_18" address="0x480" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_19" address="0x4c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_20" address="0x500" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_21" address="0x540" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_22" address="0x580" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_23" address="0x5c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_24" address="0x600" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_25" address="0x640" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_26" address="0x680" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_27" address="0x6c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_28" address="0x700" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_29" address="0x740" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_30" address="0x780" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_31" address="0x7c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_32" address="0x800" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_33" address="0x840" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_34" address="0x880" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_35" address="0x8c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_36" address="0x900" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_37" address="0x940" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_38" address="0x980" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_39" address="0x9c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_40" address="0xa00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_41" address="0xa40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_42" address="0xa80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_43" address="0xac0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_44" address="0xb00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_45" address="0xb40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_46" address="0xb80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_47" address="0xbc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_48" address="0xc00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_49" address="0xc40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_50" address="0xc80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_51" address="0xcc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_52" address="0xd00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_53" address="0xd40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_54" address="0xd80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_55" address="0xdc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_56" address="0xe00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_57" address="0xe40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_58" address="0xe80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_59" address="0xec0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_60" address="0xf00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_61" address="0xf40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_62" address="0xf80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_63" address="0xfc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
       </node>
     </node>
   </node>

--- a/scripts/address_table/uhal_gem_amc_ctp7_link10.xml
+++ b/scripts/address_table/uhal_gem_amc_ctp7_link10.xml
@@ -1649,8 +1649,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT1" address="0x800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -2749,8 +2751,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT2" address="0x1000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -3849,8 +3853,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT3" address="0x1800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -4949,8 +4955,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT4" address="0x2000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -6049,8 +6057,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT5" address="0x2800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -7149,8 +7159,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT6" address="0x3000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -8249,8 +8261,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT7" address="0x3800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -9349,8 +9363,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT8" address="0x4000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -10449,8 +10465,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT9" address="0x4800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -11549,8 +11567,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT10" address="0x5000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -12649,8 +12669,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT11" address="0x5800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -13749,8 +13771,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT12" address="0x6000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -14849,8 +14873,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT13" address="0x6800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -15949,8 +15975,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT14" address="0x7000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -17049,8 +17077,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT15" address="0x7800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -18149,8 +18179,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT16" address="0x8000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -19249,8 +19281,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT17" address="0x8800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -20349,8 +20383,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT18" address="0x9000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -21449,8 +21485,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT19" address="0x9800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -22549,8 +22587,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT20" address="0xa000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -23649,8 +23689,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT21" address="0xa800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -24749,8 +24791,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT22" address="0xb000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -25849,8 +25893,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT23" address="0xb800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -26949,8 +26995,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
         </node>
       </node>
@@ -27004,6 +27052,1864 @@
         <node id="OH_FPGA_OH9" address="0x20708" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH10" address="0x207d0" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH11" address="0x20898" permission="rw" mode="block"size="200"/>
+      </node>
+    </node>
+    <node id="OPTICAL_LINKS" address="0x1400000" >
+      <node id="MGT_CHANNEL_0" address="0x0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_1" address="0x40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_2" address="0x80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_3" address="0xc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_4" address="0x100" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_5" address="0x140" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_6" address="0x180" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_7" address="0x1c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_8" address="0x200" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_9" address="0x240" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_10" address="0x280" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_11" address="0x2c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_12" address="0x300" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_13" address="0x340" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_14" address="0x380" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_15" address="0x3c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_16" address="0x400" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_17" address="0x440" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_18" address="0x480" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_19" address="0x4c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_20" address="0x500" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_21" address="0x540" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_22" address="0x580" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_23" address="0x5c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_24" address="0x600" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_25" address="0x640" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_26" address="0x680" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_27" address="0x6c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_28" address="0x700" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_29" address="0x740" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_30" address="0x780" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_31" address="0x7c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_32" address="0x800" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_33" address="0x840" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_34" address="0x880" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_35" address="0x8c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_36" address="0x900" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_37" address="0x940" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_38" address="0x980" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_39" address="0x9c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_40" address="0xa00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_41" address="0xa40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_42" address="0xa80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_43" address="0xac0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_44" address="0xb00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_45" address="0xb40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_46" address="0xb80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_47" address="0xbc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_48" address="0xc00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_49" address="0xc40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_50" address="0xc80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_51" address="0xcc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_52" address="0xd00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_53" address="0xd40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_54" address="0xd80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_55" address="0xdc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_56" address="0xe00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_57" address="0xe40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_58" address="0xe80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_59" address="0xec0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_60" address="0xf00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_61" address="0xf40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_62" address="0xf80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_63" address="0xfc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
       </node>
     </node>
   </node>

--- a/scripts/address_table/uhal_gem_amc_ctp7_link11.xml
+++ b/scripts/address_table/uhal_gem_amc_ctp7_link11.xml
@@ -1649,8 +1649,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT1" address="0x800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -2749,8 +2751,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT2" address="0x1000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -3849,8 +3853,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT3" address="0x1800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -4949,8 +4955,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT4" address="0x2000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -6049,8 +6057,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT5" address="0x2800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -7149,8 +7159,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT6" address="0x3000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -8249,8 +8261,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT7" address="0x3800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -9349,8 +9363,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT8" address="0x4000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -10449,8 +10465,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT9" address="0x4800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -11549,8 +11567,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT10" address="0x5000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -12649,8 +12669,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT11" address="0x5800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -13749,8 +13771,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT12" address="0x6000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -14849,8 +14873,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT13" address="0x6800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -15949,8 +15975,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT14" address="0x7000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -17049,8 +17077,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT15" address="0x7800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -18149,8 +18179,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT16" address="0x8000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -19249,8 +19281,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT17" address="0x8800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -20349,8 +20383,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT18" address="0x9000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -21449,8 +21485,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT19" address="0x9800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -22549,8 +22587,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT20" address="0xa000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -23649,8 +23689,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT21" address="0xa800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -24749,8 +24791,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT22" address="0xb000" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -25849,8 +25893,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
           <node id="VFAT23" address="0xb800" >
             <node id="VFAT_CHANNELS" address="0x0" >
@@ -26949,8 +26995,10 @@
             <node id="HW_ID_VER" address="0x101" permission="r" />
             <node id="TEST_REG" address="0x102" permission="rw" />
             <node id="HW_CHIP_ID" address="0x103" permission="r" />
-            <node id="ADC0" address="0x200" permission="r" mask="0x3ff"/>
-            <node id="ADC1" address="0x201" permission="r" mask="0x3ff"/>
+            <node id="ADC0_CACHED" address="0x280" permission="r" mask="0x3ff"/>
+            <node id="ADC0_UPDATE" address="0x200" permission="rw" mask="0x1"/>
+            <node id="ADC1_CACHED" address="0x281" permission="r" mask="0x3ff"/>
+            <node id="ADC1_UPDATE" address="0x201" permission="rw" mask="0x1"/>
           </node>
         </node>
       </node>
@@ -27004,6 +27052,1864 @@
         <node id="OH_FPGA_OH9" address="0x20708" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH10" address="0x207d0" permission="rw" mode="block"size="200"/>
         <node id="OH_FPGA_OH11" address="0x20898" permission="rw" mode="block"size="200"/>
+      </node>
+    </node>
+    <node id="OPTICAL_LINKS" address="0x1400000" >
+      <node id="MGT_CHANNEL_0" address="0x0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_1" address="0x40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_2" address="0x80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_3" address="0xc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_4" address="0x100" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_5" address="0x140" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_6" address="0x180" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_7" address="0x1c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_8" address="0x200" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_9" address="0x240" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_10" address="0x280" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_11" address="0x2c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_12" address="0x300" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_13" address="0x340" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_14" address="0x380" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_15" address="0x3c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_16" address="0x400" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_17" address="0x440" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_18" address="0x480" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_19" address="0x4c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_20" address="0x500" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_21" address="0x540" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_22" address="0x580" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_23" address="0x5c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_24" address="0x600" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_25" address="0x640" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_26" address="0x680" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_27" address="0x6c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_28" address="0x700" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_29" address="0x740" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_30" address="0x780" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_31" address="0x7c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_32" address="0x800" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_33" address="0x840" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_34" address="0x880" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_35" address="0x8c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_36" address="0x900" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_37" address="0x940" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_38" address="0x980" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_39" address="0x9c0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_40" address="0xa00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_41" address="0xa40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_42" address="0xa80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_43" address="0xac0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_44" address="0xb00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_45" address="0xb40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_46" address="0xb80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_47" address="0xbc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_48" address="0xc00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_49" address="0xc40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_50" address="0xc80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_51" address="0xcc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_52" address="0xd00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_53" address="0xd40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_54" address="0xd80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_55" address="0xdc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_56" address="0xe00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_57" address="0xe40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_58" address="0xe80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_59" address="0xec0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_60" address="0xf00" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_61" address="0xf40" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_62" address="0xf80" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
+      </node>
+      <node id="MGT_CHANNEL_63" address="0xfc0" >
+        <node id="RESET" address="0x1" permission="rw" mask="0x3">
+          <node id="TX_RESET" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_RESET" address="0x0" permission="rw" mask="0x2"/>
+        </node>
+        <node id="CTRL" address="0x2" permission="rw" mask="0x7f">
+          <node id="TX_POWERDOWN" address="0x0" permission="rw" mask="0x1"/>
+          <node id="RX_POWERDOWN" address="0x0" permission="rw" mask="0x2"/>
+          <node id="TX_POLARITY" address="0x0" permission="rw" mask="0x4"/>
+          <node id="RX_POLARITY" address="0x0" permission="rw" mask="0x8"/>
+          <node id="LOOPBACK" address="0x0" permission="rw" mask="0x10"/>
+          <node id="TX_INHIBIT" address="0x0" permission="rw" mask="0x20"/>
+          <node id="RX_LOW_POWER_MODE" address="0x0" permission="rw" mask="0x40"/>
+          <node id="RX_PRBS_SEL" address="0x1" permission="rw" mask="0x7"/>
+          <node id="TX_PRBS_SEL" address="0x1" permission="rw" mask="0x70"/>
+          <node id="PRBS_CNT_RESET" address="0x2" permission="w" mask="0x1"/>
+          <node id="RX_ERROR_CNT_RESET" address="0x3" permission="w" mask="0x1"/>
+        </node>
+        <node id="STATUS" address="0x0" permission="r" mask="0xf">
+          <node id="TX_RESET_DONE" address="0x0" permission="r" mask="0x1"/>
+          <node id="RX_RESET_DONE" address="0x0" permission="r" mask="0x2"/>
+          <node id="CPLL_LOCKED" address="0x0" permission="r" mask="0x4"/>
+          <node id="CPLL_REF_CLK_LOST" address="0x0" permission="r" mask="0x8"/>
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="PRBS_ERROR_CNT" address="0x4" permission="r" />
+          <node id="RX_NOT_IN_TABLE_CNT" address="0x5" permission="r" />
+          <node id="RX_DISPERR_CNT" address="0x6" permission="r" />
+        </node>
       </node>
     </node>
   </node>

--- a/scripts/ctp7_bash_scripts/gth_status.sh
+++ b/scripts/ctp7_bash_scripts/gth_status.sh
@@ -30,6 +30,8 @@ printf "------------------------------------------------------------------------
                 gth_ctrl_base_reg=$(($gth_ctrl_base_reg+256))
                 gth_prbs_sel_base_reg=$(($gth_prbs_sel_base_reg+256))
                 gth_prbs_cnt_base_reg=$(($gth_prbs_cnt_base_reg+256))
+		gth_rx_notintable_cnt_base_reg=$(($gth_rx_notintable_cnt_base_reg+256))
+		gth_rx_disperr_cnt_base_reg=$(($gth_rx_disperr_cnt_base_reg+256))
 
         done
 printf "--------------------------------------------------------------------------------------------------\n"


### PR DESCRIPTION
v3.8.1 Bugfix in the OH FPGA communication FSM
v3.8.2 Added BC0 and RESYNC markers to the trigger receivers (backwards compatible with older OH fw versions). For now it's not doing anything with those, but just doesn't count them as errors.
v3.8.3 Fixed the trigger link missed comma counter so that it starts counting errors after 128 clock cycles after reset (previously it would only start counting after the first occurrence of good frame marker, which sometimes made a link look good even if it was completely bad)