### PR TITLE
v3.12.3 -- CPLL power-down control added to the GTH control register …

### DIFF
--- a/common/hdl/pkg/gem_pkg.vhd
+++ b/common/hdl/pkg/gem_pkg.vhd
@@ -13,7 +13,7 @@ package gem_pkg is
     constant C_FIRMWARE_DATE    : std_logic_vector(31 downto 0) := x"20201120";
     constant C_FIRMWARE_MAJOR   : integer range 0 to 255        := 3;
     constant C_FIRMWARE_MINOR   : integer range 0 to 255        := 12;
-    constant C_FIRMWARE_BUILD   : integer range 0 to 255        := 2;
+    constant C_FIRMWARE_BUILD   : integer range 0 to 255        := 3;
     
     ------ Change log ------
     -- 1.8.6 no gbt sync procedure with oh
@@ -130,6 +130,7 @@ package gem_pkg is
     -- 3.12.0 Changed the order of VFATs in GE2/1 to correspond to the silkscreen of the newest GEBs instead of the J number
     -- 3.12.1 Sector ID register added that is used in the trigger TX to EMTF, also OH mask is now used in trigger TX; ipbus reset has been fixed and separated from the global reset register; legacy GLIB registers removed
     -- 3.12.2 L1A delay setting added. TTC module calibration mode is simplified - enabling calibration mode simply triggers the calpulse on L1A, and then the L1A can be delayed using the new delay setting
+    -- 3.12.3 CPLL power-down control added to the GTH control register (bit 7) - this should be used before resetting the CPLL
 
     --======================--
     --==      General     ==--

--- a/ctp7/hdl/system/gth_register_file.vhd
+++ b/ctp7/hdl/system/gth_register_file.vhd
@@ -49,7 +49,8 @@ entity gth_register_file is
 
     gth_gt_txreset_o    : out std_logic_vector(g_NUM_OF_GTH_GTs-1 downto 0);
     gth_gt_rxreset_o    : out std_logic_vector(g_NUM_OF_GTH_GTs-1 downto 0);
-    gth_gt_cpllreset_o  : out std_logic_vector(g_NUM_OF_GTH_GTs-1 downto 0);
+    
+    gth_cpll_init_arr_o : out t_gth_cpll_init_arr(g_NUM_OF_GTH_GTs-1 downto 0);
 
     gth_gt_txreset_done_i : in std_logic_vector(g_NUM_OF_GTH_GTs-1 downto 0);
     gth_gt_rxreset_done_i : in std_logic_vector(g_NUM_OF_GTH_GTs-1 downto 0);
@@ -93,6 +94,7 @@ architecture gth_register_file_arch of gth_register_file is
   signal s_tx_polarity  : std_logic_vector(g_NUM_OF_GTH_GTs-1 downto 0);
   signal s_tx_inhibit   : std_logic_vector(g_NUM_OF_GTH_GTs-1 downto 0);
   signal s_rx_lpmen     : std_logic_vector(g_NUM_OF_GTH_GTs-1 downto 0);
+  signal s_cpll_pd      : std_logic_vector(g_NUM_OF_GTH_GTs-1 downto 0);
 
   signal s_reg_cplllock       : std_logic_vector(g_NUM_OF_GTH_GTs-1 downto 0);
   signal s_reg_cpllrefclklost : std_logic_vector(g_NUM_OF_GTH_GTs-1 downto 0);
@@ -1120,7 +1122,8 @@ begin
     gth_rx_ctrl_arr_o(i).rxlpmen    <= s_rx_lpmen(i);
     gth_misc_ctrl_arr_o(i).loopback <= "000" when s_gth_loopback(i) = '0' else "010";
 
-    gth_gt_cpllreset_o(i)           <= s_cpll_reset(i);
+    gth_cpll_init_arr_o(i).cpllreset <= s_cpll_reset(i);
+    gth_cpll_init_arr_o(i).cpllpd    <= s_cpll_pd(i);
 
     gth_tx_ctrl_arr_o(i).txpd <= "00" when s_tx_pd(i) = '0' else "11";
     gth_rx_ctrl_arr_o(i).rxpd <= "00" when s_rx_pd(i) = '0' else "11";
@@ -1153,6 +1156,7 @@ begin
     s_gth_loopback(i) <= s_gth_ctrl_reg(i)(4);
     s_tx_inhibit(i)   <= s_gth_ctrl_reg(i)(5);
     s_rx_lpmen(i)     <= s_gth_ctrl_reg(i)(6);
+    s_cpll_pd(i)      <= s_gth_ctrl_reg(i)(7);
 
   end generate;
 

--- a/ctp7/hdl/system/gth_single_10p24g.vhd
+++ b/ctp7/hdl/system/gth_single_10p24g.vhd
@@ -898,7 +898,8 @@ begin
 
 --  s_cpll_reset <= s_cpllreset_sync or s_cpllreset_ovrd;
 
-  s_cpll_reset <= gth_cpll_init_i.CPLLRESET;
+  s_cpll_reset <= gth_cpll_init_i.cpllreset;
+  s_cpll_pd <= gth_cpll_init_i.cpllpd;
 
 end gth_single_10p24g_arch;
 --============================================================================

--- a/ctp7/hdl/system/gth_single_2p56g.vhd
+++ b/ctp7/hdl/system/gth_single_2p56g.vhd
@@ -864,7 +864,8 @@ begin
 
 --  s_cpll_reset <= s_cpllreset_sync or s_cpllreset_ovrd;
 
-  s_cpll_reset <= gth_cpll_init_i.CPLLRESET;
+  s_cpll_reset <= gth_cpll_init_i.cpllreset;
+  s_cpll_pd <= gth_cpll_init_i.cpllpd;
 
 end gth_single_2p56g_arch;
 --============================================================================

--- a/ctp7/hdl/system/gth_single_3p2g.vhd
+++ b/ctp7/hdl/system/gth_single_3p2g.vhd
@@ -876,7 +876,8 @@ begin
 
 --  s_cpll_reset <= s_cpllreset_sync or s_cpllreset_ovrd;
 
-  s_cpll_reset <= gth_cpll_init_i.CPLLRESET;
+  s_cpll_reset <= gth_cpll_init_i.cpllreset;
+  s_cpll_pd <= gth_cpll_init_i.cpllpd;
 
 end gth_single_3p2g_arch;
 --============================================================================

--- a/ctp7/hdl/system/gth_single_4p8g.vhd
+++ b/ctp7/hdl/system/gth_single_4p8g.vhd
@@ -877,7 +877,8 @@ end generate;
 
 --  s_cpll_reset <= s_cpllreset_sync or s_cpllreset_ovrd;
 
-  s_cpll_reset <= gth_cpll_init_i.CPLLRESET;
+  s_cpll_reset <= gth_cpll_init_i.cpllreset;
+  s_cpll_pd <= gth_cpll_init_i.cpllpd;
 
 end gth_single_4p8g_arch;
 --============================================================================

--- a/ctp7/hdl/system/gth_single_9p6g.vhd
+++ b/ctp7/hdl/system/gth_single_9p6g.vhd
@@ -875,7 +875,8 @@ begin
 
 --  s_cpll_reset <= s_cpllreset_sync or s_cpllreset_ovrd;
 
-  s_cpll_reset <= gth_cpll_init_i.CPLLRESET;
+  s_cpll_reset <= gth_cpll_init_i.cpllreset;
+  s_cpll_pd <= gth_cpll_init_i.cpllpd;
 
 end gth_single_9p6g_arch;
 --============================================================================

--- a/ctp7/hdl/system/gth_single_tx_10p24g_rx_3p2g.vhd
+++ b/ctp7/hdl/system/gth_single_tx_10p24g_rx_3p2g.vhd
@@ -886,7 +886,8 @@ begin
 
 --  s_cpll_reset <= s_cpllreset_sync or s_cpllreset_ovrd;
 
-  s_cpll_reset <= gth_cpll_init_i.CPLLRESET;
+  s_cpll_reset <= gth_cpll_init_i.cpllreset;
+  s_cpll_pd <= gth_cpll_init_i.cpllpd;
 
 end gth_single_tx_10p24g_rx_3p2g_arch;
 --============================================================================

--- a/ctp7/hdl/system/gth_wrapper.vhd
+++ b/ctp7/hdl/system/gth_wrapper.vhd
@@ -62,7 +62,7 @@ entity gth_wrapper is
     
     ------------------------
 
-    gth_cpll_reset_arr_i  : in  std_logic_vector(g_NUM_OF_GTH_GTs-1 downto 0);
+    gth_cpll_init_arr_i   : in t_gth_cpll_init_arr(g_NUM_OF_GTH_GTs-1 downto 0);
     gth_cpll_status_arr_o : out t_gth_cpll_status_arr(g_NUM_OF_GTH_GTs-1 downto 0);
 
     ------------------------
@@ -807,7 +807,7 @@ begin
       s_gth_rx_init_arr(i*4+j).RXDFELFOVRDEN   <= '0';
       s_gth_rx_init_arr(i*4+j).RXLPMHFOVRDEN   <= '0';
 
-      s_gth_cpll_init_arr(i*4+j).cpllreset <= gth_cpll_reset_arr_i(i*4+j);
+      s_gth_cpll_init_arr(i*4+j) <= gth_cpll_init_arr_i(i*4+j);
 
       --------------------------------------------------------------------------
       gt_cdrlock_timeout : process(clk_stable_i)

--- a/ctp7/hdl/system/pkg/gth_pkg.vhd
+++ b/ctp7/hdl/system/pkg/gth_pkg.vhd
@@ -66,6 +66,7 @@ package gth_pkg is
 
   type t_gth_cpll_init is record
     cpllreset : std_logic;
+    cpllpd    : std_logic;
   end record;
 
   type t_gth_cpll_status is record

--- a/ctp7/hdl/system/system.vhd
+++ b/ctp7/hdl/system/system.vhd
@@ -230,7 +230,8 @@ architecture system_arch of system is
   signal s_gth_gt_rxreset_regf    : std_logic_vector(g_NUM_OF_GTH_GTs-1 downto 0);
   signal s_gth_gt_txreset         : std_logic_vector(g_NUM_OF_GTH_GTs-1 downto 0);
   signal s_gth_gt_rxreset         : std_logic_vector(g_NUM_OF_GTH_GTs-1 downto 0);
-  signal s_gth_gt_cpllreset       : std_logic_vector(g_NUM_OF_GTH_GTs-1 downto 0);
+
+  signal s_gth_cpll_init_arr      : t_gth_cpll_init_arr(g_NUM_OF_GTH_GTs-1 downto 0);
 
   signal s_gth_common_status_arr  : t_gth_common_status_arr(g_NUM_OF_GTH_COMMONs-1 downto 0);
   signal s_gth_common_drp_in_arr  : t_gth_common_drp_in_arr(g_NUM_OF_GTH_COMMONs-1 downto 0);
@@ -440,10 +441,10 @@ begin
 
       gth_common_reset_o      => s_gth_common_reset,
       gth_common_status_arr_i => s_gth_common_status_arr,
+      gth_cpll_init_arr_o     => s_gth_cpll_init_arr,
       gth_cpll_status_arr_i   => s_gth_cpll_status_arr,
       gth_gt_txreset_o        => s_gth_gt_txreset_regf,
       gth_gt_rxreset_o        => s_gth_gt_rxreset_regf,
-      gth_gt_cpllreset_o      => s_gth_gt_cpllreset,
       gth_gt_txreset_done_i   => s_gth_gt_txreset_done,
       gth_gt_rxreset_done_i   => s_gth_gt_rxreset_done,
       gth_tx_ctrl_arr_o       => s_gth_tx_ctrl_arr,
@@ -493,7 +494,8 @@ begin
 
       clk_gth_tx_usrclk_arr_o => s_clk_gth_tx_usrclk_arr,
       clk_gth_rx_usrclk_arr_o => s_clk_gth_rx_usrclk_arr,
-      gth_cpll_reset_arr_i    => s_gth_gt_cpllreset,
+
+      gth_cpll_init_arr_i     => s_gth_cpll_init_arr,
       gth_cpll_status_arr_o   => s_gth_cpll_status_arr,
 
       ttc_clks_i              => ttc_clks,

--- a/scripts/address_table/gem_amc_top.xml
+++ b/scripts/address_table/gem_amc_top.xml
@@ -1660,6 +1660,8 @@
                 description="Setting this to 1 will inhibit the TX channel (forces MGTHTXP to 0 and MGTHTXN to 1). This is an expert debug feature."/>
           <node id="RX_LOW_POWER_MODE" address="0x0" mask="0x00000040" permission="rw"
                 description="Setting this to 1 enables the RX LPM (this controls RXLPMEN). NOTE: THIS MUST ALWAYS BE SET TO 1 FOR GOOD RX PERFORMANCE WITH 8b10b ENCODING."/>
+          <node id="CPLL_POWERDOWN" address="0x0" mask="0x00000080" permission="rw"
+                description="Setting this to 1 will power down the CPLL. Note that the CPLL should be powered down and up before resetting it."/>
           <node id="RX_PRBS_SEL" address="0x1" mask="0x00000007" permission="rw"
                 description="Controls the RX PRBS mode: 000 -- normal operation (no PRBS checks), 001 -- PRBS7, 010 -- PRBS15, 011 -- PRBS23, 100 -- PRBS31"/>
           <node id="TX_PRBS_SEL" address="0x1" mask="0x00000070" permission="rw"

--- a/scripts/address_table/gem_amc_top_new_style.xml
+++ b/scripts/address_table/gem_amc_top_new_style.xml
@@ -1660,6 +1660,8 @@
                 description="Setting this to 1 will inhibit the TX channel (forces MGTHTXP to 0 and MGTHTXN to 1). This is an expert debug feature."/>
           <node id="RX_LOW_POWER_MODE" address="0x0" mask="0x00000040" permission="rw"
                 description="Setting this to 1 enables the RX LPM (this controls RXLPMEN). NOTE: THIS MUST ALWAYS BE SET TO 1 FOR GOOD RX PERFORMANCE WITH 8b10b ENCODING."/>
+          <node id="CPLL_POWERDOWN" address="0x0" mask="0x00000080" permission="rw"
+                description="Setting this to 1 will power down the CPLL. Note that the CPLL should be powered down and up before resetting it."/>
           <node id="RX_PRBS_SEL" address="0x1" mask="0x00000007" permission="rw"
                 description="Controls the RX PRBS mode: 000 -- normal operation (no PRBS checks), 001 -- PRBS7, 010 -- PRBS15, 011 -- PRBS23, 100 -- PRBS31"/>
           <node id="TX_PRBS_SEL" address="0x1" mask="0x00000070" permission="rw"

--- a/scripts/address_table/gem_amc_top_old_style.xml
+++ b/scripts/address_table/gem_amc_top_old_style.xml
@@ -3666,6 +3666,8 @@
                 description="Setting this to 1 will inhibit the TX channel (forces MGTHTXP to 0 and MGTHTXN to 1). This is an expert debug feature."/>
           <node id="RX_LOW_POWER_MODE" address="0x0" mask="0x00000040" permission="rw"
                 description="Setting this to 1 enables the RX LPM (this controls RXLPMEN). NOTE: THIS MUST ALWAYS BE SET TO 1 FOR GOOD RX PERFORMANCE WITH 8b10b ENCODING."/>
+          <node id="CPLL_POWERDOWN" address="0x0" mask="0x00000080" permission="rw"
+                description="Setting this to 1 will power down the CPLL. Note that the CPLL should be powered down and up before resetting it."/>
           <node id="RX_PRBS_SEL" address="0x1" mask="0x00000007" permission="rw"
                 description="Controls the RX PRBS mode: 000 -- normal operation (no PRBS checks), 001 -- PRBS7, 010 -- PRBS15, 011 -- PRBS23, 100 -- PRBS31"/>
           <node id="TX_PRBS_SEL" address="0x1" mask="0x00000070" permission="rw"


### PR DESCRIPTION
…(bit 7) - this should be used before resetting the CPLL